### PR TITLE
fix: preserve executable bits in package tarballs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,16 @@ jobs:
         run: ./win_install.ps1
       - name: Build
         run: npm ci
+      - name: Test packaged installation
+        if: matrix.node == 20
+        run: |
+          chmod -x configure deps/librdkafka/configure deps/librdkafka/lds-gen.py
+          npm pack
+          for script in configure deps/librdkafka/configure deps/librdkafka/lds-gen.py; do
+            tar -tzvf ./*.tgz | grep -E "^-rwxr-xr-x.*package/$script$"
+          done
+          npm install --prefix /tmp/rdkafka-package-test --foreground-scripts --no-audit --no-fund "$PWD"/platformatic-rdkafka-*.tgz
+          node -e "require('/tmp/rdkafka-package-test/node_modules/@platformatic/rdkafka')"
       # skipping on windows for now due to Make / mocha exit code issues
       - name: Test
         if: runner.os != 'Windows'

--- a/ci/ensure-executable-build-scripts.js
+++ b/ci/ensure-executable-build-scripts.js
@@ -1,0 +1,14 @@
+const fs = require('fs');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..');
+const buildScripts = [
+  'configure',
+  'deps/librdkafka/configure',
+  'deps/librdkafka/lds-gen.py',
+];
+
+for (const script of buildScripts) {
+  const scriptPath = path.join(root, script);
+  fs.chmodSync(scriptPath, fs.statSync(scriptPath).mode | 0o111);
+}

--- a/ci/prepublish.js
+++ b/ci/prepublish.js
@@ -1,3 +1,4 @@
+require('./ensure-executable-build-scripts');
 require('./checks/librdkafka-exists');
 require('./checks/librdkafka-correct-version');
 require('./librdkafka-defs-generator.js');


### PR DESCRIPTION
## Summary

Preserve executable bits for the native-build scripts in the published npm tarball.

## Root cause

The source files are executable, as are the `node-rdkafka@3.6.1` package equivalents. However, the published `@platformatic/rdkafka@4.1.0` and `4.1.0-alpha.1` artifacts contain `configure`, `deps/librdkafka/configure`, and `deps/librdkafka/lds-gen.py` as `0644`, causing native installation to fail with exit 126.

## Changes

- restore execute permission for the three scripts in `prepack`, before npm constructs the artifact;
- add a CI regression test that first removes those bits, packs the module, asserts `0755` in the tarball, then installs and loads the package.

## Validation

- removed the three execute bits locally before packing;
- verified all three files are `0755` in the packed tarball;
- installed the tarball, completed the native build, and loaded the binding.
