### PR TITLE
fix: preserve executable bits in published tarballs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Release
+
+on:
+  release:
+    types: ["published"]
+
+jobs:
+  publish:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 22
+          registry-url: "https://registry.npmjs.org"
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+      - name: Verify the tarball keeps the executable bit on build scripts
+        run: node ci/checks/tarball-executable-bits.js
+      # Publish with npm, never pnpm. pnpm's packer synthesizes tar entry modes
+      # and marks only `bin` entries executable, which strips the executable bit
+      # from configure and lds-gen.py and breaks every clean native install.
+      # That is what shipped in 4.1.0; see ci/checks/tarball-executable-bits.js.
+      - name: Publish
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,3 +56,16 @@ jobs:
       - name: Test
         if: runner.os != 'Windows'
         run: npm test
+
+  pack:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 22
+      - name: Verify the tarball keeps the executable bit on build scripts
+        run: node ci/checks/tarball-executable-bits.js

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -235,3 +235,17 @@ Steps to update:
 1. Increment the `version` in `package.json` and merge that change in.
 
 1. Create a new github release. Set the tag & release title to the same string as `version` in `package.json`.
+
+Publishing then happens from the `Release` workflow, which packs and publishes
+with `npm`.
+
+__Do not publish by hand, and do not publish with `pnpm`.__ `pnpm` does not use
+`npm` to build the tarball; it has its own packer, which synthesizes the tar
+entry modes rather than reading them off disk, marking only files listed in
+`bin` as executable. That silently strips the executable bit from `configure`,
+`deps/librdkafka/configure` and `deps/librdkafka/lds-gen.py`, and every clean
+native install of the resulting package then fails with exit 126
+(`Permission denied`). This is what happened to 4.1.0 and 4.1.0-alpha.1.
+
+`node ci/checks/tarball-executable-bits.js` packs the module and asserts the
+bits survived. It runs on every pull request and again before publishing.

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ ifeq ($(BUILDTYPE),Debug)
 GYPBUILDARGS=--debug
 endif
 
-.PHONY: all clean lint test lib docs e2e ghpages check
+.PHONY: all clean lint test lib docs e2e ghpages check check-pack
 
 all: lib test e2e
 
@@ -61,6 +61,9 @@ test: node_modules/.dirstamp
 
 check: node_modules/.dirstamp
 	@$(NODE) util/test-compile.js
+
+check-pack:
+	@$(NODE) ci/checks/tarball-executable-bits.js
 
 e2e: $(E2E_TESTS)
 	@./node_modules/.bin/mocha --exit --timeout 120000 --ui exports $(TEST_REPORTER) $(E2E_TESTS) $(TEST_OUTPUT)

--- a/ci/checks/publish-with-npm.js
+++ b/ci/checks/publish-with-npm.js
@@ -1,0 +1,27 @@
+// This package may only be published with npm.
+//
+// pnpm does not delegate packing to npm. It builds the tarball with its own
+// packer, which synthesizes the tar entry modes instead of reading them off
+// disk, marking as executable only the files listed in `bin`. That strips the
+// executable bit from configure, deps/librdkafka/configure and
+// deps/librdkafka/lds-gen.py, and every clean native install of the result then
+// fails with exit 126 ("Permission denied"). 4.1.0 and 4.1.0-alpha.1 shipped
+// that way. npm packs with node-tar, which reads the real mode off disk.
+//
+// See also ci/checks/tarball-executable-bits.js, which asserts the same
+// property against a packed artifact.
+
+const userAgent = process.env.npm_config_user_agent;
+
+// Unset means we cannot tell what is driving the publish. Allow it rather than
+// break an unusual but legitimate setup; CI publishes through npm regardless.
+if (userAgent && !userAgent.startsWith('npm/')) {
+  const packageManager = userAgent.split(' ')[0];
+
+  console.error(`Refusing to publish with ${packageManager}: this package must be published with npm.`);
+  console.error('');
+  console.error(`${packageManager} rewrites file modes while packing and marks only \`bin\` entries`);
+  console.error('executable, which strips the executable bit from the native build scripts and');
+  console.error('breaks clean installs with exit 126. See CONTRIBUTING.md.');
+  process.exit(1);
+}

--- a/ci/checks/tarball-executable-bits.js
+++ b/ci/checks/tarball-executable-bits.js
@@ -1,0 +1,121 @@
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const root = path.resolve(__dirname, '..', '..');
+const librdkafkaPath = path.resolve(root, 'deps', 'librdkafka');
+
+// Packing must not drop the executable bit on the scripts the native build
+// shells out to: deps/librdkafka/src/Makefile pipes into `../lds-gen.py` and
+// deps/librdkafka.gyp runs `./configure`, so a 0644 there means a clean install
+// fails with exit 126 / "Permission denied".
+//
+// This cannot be asserted against the working tree, because the modes are lost
+// during packing rather than in the checkout: pnpm's packer synthesizes tar
+// entry modes (0755 only for files listed in `bin`, 0644 for everything else)
+// instead of reading them off disk. So pack for real and inspect the artifact.
+
+const EXEC_OWNER_COLUMN = 3;
+const TARBALL_PREFIX = 'package/';
+
+function trackedExecutables(cwd, prefix) {
+  const listing = execFileSync('git', ['ls-files', '--stage'], {
+    cwd,
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024
+  });
+
+  return listing
+    .split('\n')
+    .filter((line) => line.startsWith('100755 '))
+    .map((line) => prefix + line.slice(line.indexOf('\t') + 1));
+}
+
+function packWithNpm(destination) {
+  const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+
+  // --ignore-scripts keeps this hermetic. prepack regenerates the TypeScript
+  // definitions, which is irrelevant to file modes and slow to redo.
+  execFileSync(npm, ['pack', '--ignore-scripts', '--pack-destination', destination], {
+    cwd: root,
+    stdio: 'ignore'
+  });
+
+  const tarballs = fs.readdirSync(destination).filter((f) => f.endsWith('.tgz'));
+
+  if (tarballs.length !== 1) {
+    console.error(`Expected one tarball in ${destination}, found ${tarballs.length}`);
+    process.exit(1);
+  }
+
+  return path.join(destination, tarballs[0]);
+}
+
+function readTarballModes(tarball) {
+  const listing = execFileSync('tar', ['-tvzf', tarball], {
+    encoding: 'utf8',
+    maxBuffer: 64 * 1024 * 1024
+  });
+
+  const modes = new Map();
+
+  for (const line of listing.split('\n')) {
+    const columns = line.trim().split(/\s+/);
+    const mode = columns[0];
+    const name = columns[columns.length - 1];
+
+    // Symlinks list as `name -> target`, which would record the target instead.
+    if (!mode || mode.startsWith('l') || !name.startsWith(TARBALL_PREFIX)) {
+      continue;
+    }
+
+    modes.set(name.slice(TARBALL_PREFIX.length), mode);
+  }
+
+  return modes;
+}
+
+if (!fs.existsSync(librdkafkaPath)) {
+  console.error(`Could not find librdkafka at path ${librdkafkaPath}`);
+  console.error('Run `git submodule update --init --recursive` first.');
+  process.exit(1);
+}
+
+const expected = trackedExecutables(root, '')
+  .concat(trackedExecutables(librdkafkaPath, 'deps/librdkafka/'));
+
+const destination = fs.mkdtempSync(path.join(os.tmpdir(), 'rdkafka-pack-'));
+let packed;
+let modes;
+
+try {
+  modes = readTarballModes(packWithNpm(destination));
+  packed = expected.filter((file) => modes.has(file));
+} finally {
+  fs.rmSync(destination, { recursive: true, force: true });
+}
+
+// If nothing lined up, the tar listing failed to parse or .npmignore changed
+// shape. Either way the check is no longer proving anything, so fail loudly
+// rather than passing vacuously.
+if (packed.length === 0) {
+  console.error('No executable files from git were found in the tarball at all.');
+  console.error(`Tarball entries inspected: ${modes.size}`);
+  process.exit(1);
+}
+
+const stripped = packed.filter((file) => modes.get(file)[EXEC_OWNER_COLUMN] !== 'x');
+
+if (stripped.length > 0) {
+  console.error(`${stripped.length} of ${packed.length} packed files lost their executable bit:`);
+  for (const file of stripped) {
+    console.error(`  ${modes.get(file)} ${file}`);
+  }
+  console.error('');
+  console.error('Pack and publish with npm. pnpm rewrites tar entry modes and');
+  console.error('marks only `bin` entries executable, which breaks native builds.');
+  process.exit(1);
+}
+
+console.log(`All ${packed.length} executable files kept mode 0755 in the tarball.`);

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "build": "node-gyp build --debug",
     "test": "make test",
     "install": "node-gyp rebuild",
-    "prepack": "node ./ci/prepublish.js"
+    "prepack": "node ./ci/prepublish.js",
+    "prepublishOnly": "node ./ci/checks/publish-with-npm.js"
   },
   "keywords": [
     "kafka",

--- a/util/configure.js
+++ b/util/configure.js
@@ -18,6 +18,47 @@ if (isWin) {
 
 var childProcess = require('child_process');
 
+// Scripts the native build shells out to directly: this file runs ./configure,
+// which in turn runs deps/librdkafka/configure, and deps/librdkafka/src/Makefile
+// pipes into ../lds-gen.py. All three need the executable bit or the build dies
+// with exit 126 / "Permission denied".
+//
+// Some package managers synthesize tar entry modes when packing instead of
+// reading them off disk (pnpm marks only `bin` entries executable), so a
+// published tarball can arrive with these at 0644 even though they are 0755 in
+// git. Restore the bit here so an install works whatever produced the tarball.
+var executableBuildScripts = [
+  'configure',
+  'deps/librdkafka/configure',
+  'deps/librdkafka/lds-gen.py'
+];
+
+executableBuildScripts.forEach(function(script) {
+  var scriptPath = path.join(baseDir, script);
+  var mode;
+
+  try {
+    mode = fs.statSync(scriptPath).mode & parseInt('777', 8);
+  } catch (e) {
+    // Missing file. Let the build below fail with its own, clearer error.
+    return;
+  }
+
+  // Mirror the read bits into the execute bits, the same way `chmod +x` does.
+  var executableMode = mode | ((mode & parseInt('444', 8)) >> 2);
+
+  if (executableMode === mode) {
+    return;
+  }
+
+  try {
+    fs.chmodSync(scriptPath, executableMode);
+  } catch (e) {
+    process.stderr.write('Could not restore the executable bit on ' + script +
+      ': ' + e.message + '\n');
+  }
+});
+
 try {
   childProcess.execSync('./configure --prefix=' + releaseDir + ' --libdir=' + releaseDir, {
     cwd: baseDir,


### PR DESCRIPTION
Fixes #58.

## Scope

Wider than reported: **every** executable file lost the bit, not three.

| | modes |
|---|---|
| 4.0.1 | 711 files `0644`, 58 files `0755` |
| 4.1.0 | 786 files `0644`, **0 files `0755`** |

## Root cause

The modes are lost **while packing**, not in the checkout — which is why the source files being `100755` in git didn't help.

`pnpm` does not delegate packing to npm. It builds the tarball with its own packer (`plugin-commands-publishing/lib/pack.js`) and only shells out to `npm publish <tarball>` afterwards to upload the finished bytes:

```js
const isExecutable = bins.some((bin) => path.relative(bin, source) === "");
const mode = isExecutable ? 493 : 420;        // 0o755 : 0o644
pack.entry({ mode, mtime, name }, fs.readFileSync(source));
```

It never stats the file. The mode is synthesized from one question — "is this declared in `bin`?" — so build scripts invoked from a Makefile are `0644` unconditionally. npm packs with node-tar, which stats each file; that's why 4.0.1 was correct. Reproduces identically on pnpm 9 and 10.

Corroborating evidence on the published artifacts: 4.0.1 carries `_npmVersion: 11.13.0` and a `prepack` entry; 4.1.0 and 4.1.0-alpha.1 have neither. Both omissions reproduce exactly under `pnpm pack`.

This also means **no `prepack` chmod can fix it** — pnpm overrides the mode at tar-write time regardless of what's on disk. That's why #57 wouldn't have worked, as @bcomnes correctly called out when closing it.

## Changes

**1. `util/configure.js` — installs survive a broken tarball.** Restores the bit on the three scripts the build invokes directly (`configure`, `deps/librdkafka/configure`, `deps/librdkafka/lds-gen.py`). This is the only layer that helps users already on a bad artifact.

**2. `ci/checks/tarball-executable-bits.js` — CI catches a stripped artifact.** Packs with npm and asserts every file git tracks as `100755` (here and in the submodule) kept the bit. Fails loudly if it matches zero files so it can't pass vacuously. Runs on every PR; also `make check-pack`.

**3. Publish path — the cause can't recur.** A CI check alone wouldn't have prevented this, since the break happened outside CI. `release.yml` publishes from CI with `npm publish --provenance`, and a `prepublishOnly` check refuses a manual publish from a package manager that rewrites modes.

## Validation

Control vs treatment against the **actual published 4.1.0 tarball**:

| | result |
|---|---|
| 4.1.0 as published | `/bin/sh: ./configure: Permission denied` → exit 1 |
| 4.1.0 + this patch | exit 0, binding loads, `librdkafka 2.12.0` |

The check itself, both directions:

```
$ make check-pack
All 64 executable files kept mode 0755 in the tarball.

$ chmod 644 configure deps/librdkafka/lds-gen.py && make check-pack
2 of 64 packed files lost their executable bit:
  -rw-r--r-- configure
  -rw-r--r-- deps/librdkafka/lds-gen.py
```

The `prepublishOnly` guard was confirmed to actually fire under pnpm, with `npm_config_user_agent` cleanly distinguishing packers (`pnpm/9.15.0 npm/?` vs `npm/11.12.1`).

## Before merging / after

- **`NPM_TOKEN` secret** must be added to the repo before `release.yml` can publish.
- **4.1.0 can't be repaired in place** — this needs a 4.1.1. I left the version bump out, as that's a maintainer call.

## Notes

- `make test` and `make jslint` fail on `main` before this branch (flaky broker-transport tests; 27 pre-existing lint errors in `lib/`, `test/`, `e2e/`). No files involved in either are touched here.
- `package-lock.json` has unrelated pre-existing drift in the working tree; deliberately left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01972oG2yVAYivv34zrPcxpF
